### PR TITLE
Fix message content

### DIFF
--- a/src/main/scala/com/knoldus/MQTTPublisher.scala
+++ b/src/main/scala/com/knoldus/MQTTPublisher.scala
@@ -33,8 +33,8 @@ object MQTTPublisher extends App {
       client = new MqttClient(brokerUrl, MqttClient.generateClientId, persistence)
       client.connect()
       val msgTopic = client.getTopic(topic)
-      val message = new MqttMessage(getMessage.getBytes("utf-8"))
       while (true) {
+        val message = new MqttMessage(getMessage.getBytes("utf-8"))
         msgTopic.publish(message)
         println(s"Publishing the data topic ${msgTopic.getName} message: ${message.toString}")
         Thread.sleep(1000)
@@ -48,5 +48,5 @@ object MQTTPublisher extends App {
     }
   }
 
-  publishToserver
+  publishToserver()
 }

--- a/src/main/scala/com/knoldus/MQTTSubscriber.scala
+++ b/src/main/scala/com/knoldus/MQTTSubscriber.scala
@@ -25,14 +25,14 @@ object MQTTSubscriber extends App {
     val topic = "TemperatureEvent"
     val persistence = new MemoryPersistence
     val client = new MqttClient(brokerUrl, MqttClient.generateClientId, persistence)
-    client.connect
+    client.connect()
     client.subscribe(topic)
     val callback = new MqttCallBackImpl
     client.setCallback(callback)
 
   }
 
-  subscribeToCommands
+  subscribeToCommands()
 }
 
 class MqttCallBackImpl extends MqttCallback {


### PR DESCRIPTION
- Set message content inside the `while` loop in the publisher, so it is different every time
- Added parentheses to calls to methods that are defined with empty parentheses to resolve some warnings